### PR TITLE
Stop click event propagation beyond ScaleImage

### DIFF
--- a/scaleimage-addon/src/main/java/org/vaadin/alump/scaleimage/gwt/client/conn/ScaleImageConnector.java
+++ b/scaleimage-addon/src/main/java/org/vaadin/alump/scaleimage/gwt/client/conn/ScaleImageConnector.java
@@ -74,6 +74,7 @@ public class ScaleImageConnector extends AbstractComponentConnector {
         protected void fireClick(NativeEvent event,
                 MouseEventDetails mouseDetails) {
             getRpcProxy(ScaleImageServerRpc.class).click(mouseDetails);
+            event.stopPropagation();
         }
 
     };


### PR DESCRIPTION
Needed to add this when using ScaleImage instead of a button. Otherwise the surrouding layout would receive clicks as well.
